### PR TITLE
Add a markdown-specific configuration for bracket closing

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -9,7 +9,7 @@ import {
 import { foldGutter, indentUnit } from "@codemirror/language";
 
 import { autoSaveContent } from "./save.js";
-import { closeBrackets } from "@codemirror/autocomplete";
+import { customCloseBracketsExtension } from "./extensions.js";
 import { customSetup } from "./setup.js";
 import { ednaKeymap } from "./keymap.js";
 import { emacsKeymap } from "./emacs.js";
@@ -25,7 +25,7 @@ import { links } from "./links.js";
 import { markdown } from "@codemirror/lang-markdown";
 import { todoCheckboxPlugin } from "./todo-checkbox";
 import { findEditorByView } from "../state.js";
-import { isReadOnly } from "./cmutils.js"
+import { isReadOnly } from "./cmutils.js";
 
 function getKeymapExtensions(editor, keymap) {
   if (keymap === "emacs") {
@@ -93,7 +93,7 @@ export class EdnaEditor {
           this.foldGutterCompartment.of(showFoldGutter ? [foldGutter()] : []),
 
           this.closeBracketsCompartment.of(
-            bracketClosing ? [closeBrackets()] : [],
+            bracketClosing ? customCloseBracketsExtension : [],
           ),
 
           this.readOnlyCompartment.of([]),
@@ -251,7 +251,7 @@ export class EdnaEditor {
   setBracketClosing(value) {
     this.view.dispatch({
       effects: this.closeBracketsCompartment.reconfigure(
-        value ? [closeBrackets()] : [],
+        value ? customCloseBracketsExtension : [],
       ),
     });
   }

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -9,7 +9,7 @@ import {
 import { foldGutter, indentUnit } from "@codemirror/language";
 
 import { autoSaveContent } from "./save.js";
-import { customCloseBracketsExtension } from "./extensions.js";
+import { createDynamicCloseBracketsExtension } from "./extensions.js";
 import { customSetup } from "./setup.js";
 import { ednaKeymap } from "./keymap.js";
 import { emacsKeymap } from "./emacs.js";
@@ -93,7 +93,7 @@ export class EdnaEditor {
           this.foldGutterCompartment.of(showFoldGutter ? [foldGutter()] : []),
 
           this.closeBracketsCompartment.of(
-            bracketClosing ? customCloseBracketsExtension : [],
+            bracketClosing ? createDynamicCloseBracketsExtension() : [],
           ),
 
           this.readOnlyCompartment.of([]),
@@ -251,7 +251,7 @@ export class EdnaEditor {
   setBracketClosing(value) {
     this.view.dispatch({
       effects: this.closeBracketsCompartment.reconfigure(
-        value ? customCloseBracketsExtension : [],
+        value ? createDynamicCloseBracketsExtension() : [],
       ),
     });
   }

--- a/src/editor/extensions.js
+++ b/src/editor/extensions.js
@@ -1,18 +1,37 @@
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
 import { EditorState } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
+import { getActiveNoteBlock } from "./block/block.js";
 
-export const customCloseBracketsConfig = EditorState.languageData.of(() => [
-  {
-    closeBrackets: {
-      brackets: ["(", "[", "{", "'", '"', "*"],
-      before: ")]}:;>*",
-    },
+const defaultCloseBracketsConfig = {
+  closeBrackets: {
+    brackets: ["(", "[", "{", "'", '"'],
+    before: ")]}:;>",
   },
-]);
+};
 
-export const customCloseBracketsExtension = [
-  closeBrackets(),
-  keymap.of(closeBracketsKeymap),
-  customCloseBracketsConfig,
-];
+const markdownCloseBracketsConfig = {
+  closeBrackets: {
+    brackets: ["(", "[", "{", "'", '"', "*", "_", "`"],
+    before: ")]}:;>*_`",
+  },
+};
+
+/**
+ * Creates a dynamic close brackets extension that changes behavior based on the current block's language.
+ * @returns {import("@codemirror/state").Extension}
+ */
+export function createDynamicCloseBracketsExtension() {
+  return [
+    closeBrackets(),
+    keymap.of(closeBracketsKeymap),
+    EditorState.languageData.of((state) => {
+      const block = getActiveNoteBlock(state);
+      if (block && block.language && block.language.name === "markdown") {
+        return [markdownCloseBracketsConfig];
+      } else {
+        return [defaultCloseBracketsConfig];
+      }
+    }),
+  ];
+}

--- a/src/editor/extensions.js
+++ b/src/editor/extensions.js
@@ -1,0 +1,18 @@
+import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import { EditorState } from "@codemirror/state";
+import { keymap } from "@codemirror/view";
+
+export const customCloseBracketsConfig = EditorState.languageData.of(() => [
+  {
+    closeBrackets: {
+      brackets: ["(", "[", "{", "'", '"', "*"],
+      before: ")]}:;>*",
+    },
+  },
+]);
+
+export const customCloseBracketsExtension = [
+  closeBrackets(),
+  keymap.of(closeBracketsKeymap),
+  customCloseBracketsConfig,
+];


### PR DESCRIPTION
When writing in markdown - specifically, when bolding or italicizing text in markdown - it's useful to have asterisks automatically wrap the selected text. Same goes go backticks and underscores.

This functionality is available through `codemirror`'s [automatic bracket closing](https://codemirror.net/docs/ref/#autocomplete.CloseBracketConfig), but it only supports characters `["(", "[", "{", "'", '"']` by default.

From a technical standpoint, this change adds a custom `closeBrackets` configuration to include asterisks, backticks, and underscores.
From a user standpoint, it allows users to select text, type the asterisk key (`*`) and have the text be wrapped in asterisks. It allows for easy italicizing and bolding of texts.

~~## Issues~~

~~Unfortunately, I do not yet have the Javascript knowledge to enable this change only for markdown blocks and/or selected text.~~

~~This means that when the "Auto-close quotation marks and brackets" setting is enabled and an asterisk is typed, it results in two asterisks being typed. This is an issue if typing in math blocks or other programming language blocks.~~

~~**I do not recommend merging this PR until a more appropriate solution is developed.**~~

I've made the appropriate changes such that the markdown-specific `closeBrackets` configuration is only ran in markdown blocks. 
